### PR TITLE
Added a more accurate ExtraLine to Jungle Secrets Quest

### DIFF
--- a/A30-60.lua
+++ b/A30-60.lua
@@ -3063,7 +3063,7 @@ AAPClassic.PathA2 = {
 			["Zone"] = "33 (Stranglethorn Vale)",
 		}, -- [4]
 		{
-			["ExtraLine"] = "He patrols",
+			["ExtraLine"] = "Thorsen patrol starts at Camp. He must survive!",
 			["TT"] = {
 				["y"] = -11465.7,
 				["x"] = -292.5,


### PR DESCRIPTION
This quest can be confusing to start for players unfamiliar with it. Changed the ExtraLine to provide the player with more information.